### PR TITLE
tests: Sort []attribute.KeyValue before comparing them

### DIFF
--- a/attr_test.go
+++ b/attr_test.go
@@ -1,7 +1,9 @@
 package otelattr
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -255,6 +257,13 @@ func TestMarshalOtelAttributes__WithMap(t *testing.T) {
 
 func assertAttributes(tb testing.TB, want, got []attribute.KeyValue, msgAndArgs ...interface{}) bool {
 	tb.Helper()
+
+	sortKV := func(i, j attribute.KeyValue) int {
+		return cmp.Compare(i.Key, j.Key)
+	}
+	slices.SortFunc(want, sortKV)
+	slices.SortFunc(got, sortKV)
+
 	if !assert.ObjectsAreEqualValues(want, got) {
 		return assert.Fail(tb,
 			fmt.Sprintf(


### PR DESCRIPTION
Hello @mashiike -san 👋🏽

I noticed some tests were failing due to unsorted slices, so I made a quick fix for that. Hope it helps!